### PR TITLE
Don't use file system concrete. Use new contracts.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.x",
-        "illuminate/filesystem": "4.x",
+        "illuminate/contracts": "~4.3",
         "knplabs/knp-snappy": "*"
     },
     "autoload": {

--- a/src/Barryvdh/Snappy/IlluminateSnappyImage.php
+++ b/src/Barryvdh/Snappy/IlluminateSnappyImage.php
@@ -1,12 +1,12 @@
 <?php namespace Barryvdh\Snappy;
 
 use Knp\Snappy\Image;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Filesystem\Filesystem;
 
 class IlluminateSnappyImage extends Image {
 
 	/**
-	 * @param \Illuminate\Filesystem\Filesystem
+	 * @param \Illuminate\Contracts\Filesystem\Filesystem
      * @param string $binary
      * @param array $options
 	 */

--- a/src/Barryvdh/Snappy/IlluminateSnappyPdf.php
+++ b/src/Barryvdh/Snappy/IlluminateSnappyPdf.php
@@ -1,12 +1,12 @@
 <?php namespace Barryvdh\Snappy;
 
 use Knp\Snappy\Pdf;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Filesystem\Filesystem;
 
 class IlluminateSnappyPdf extends Pdf {
 
 	/**
-	 * @param \Illuminate\Filesystem\Filesystem
+	 * @param \Illuminate\Contracts\Filesystem\Filesystem
      * @param string $binary
      * @param array $options
 	 */


### PR DESCRIPTION
My argument for using the file system back in #8 `https://laracasts.com/series/whats-new-in-laravel-4-3/episodes/6` kind of shows support for cloud in the box.

Anyhow, in 4.3 Laravel will have contracts so when released might good to merge this to allow using which ever implementation :)
