### PR TITLE
Use fully-qualified class names in return docblocks for download and stream methods of PdfWrapper

### DIFF
--- a/src/PdfWrapper.php
+++ b/src/PdfWrapper.php
@@ -182,7 +182,7 @@ class PdfWrapper{
      * Make the PDF downloadable by the user
      *
      * @param string $filename
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function download($filename = 'document.pdf')
     {
@@ -196,7 +196,7 @@ class PdfWrapper{
      * Return a response with the PDF to show in the browser
      *
      * @param string $filename
-     * @return StreamedResponse
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
     public function stream($filename = 'document.pdf')
     {


### PR DESCRIPTION
Use fully-qualified class names in return docblocks for download and stream methods of PdfWrapper.