### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ For example, when loaded with composer, the line should look like:
     
 If you followed the vagrant steps, the line should look like:
 
-    'binary'  => '/usr/local/bin/wkhtmltopdf',
+    'binary'  => '/usr/local/bin/wkhtmltopdf-amd64',
 
 ### Lumen
 In `bootstrap/app.php` add:


### PR DESCRIPTION
In your documentation for vagrant you use:

`cp vendor/h4cc/wkhtmltopdf-amd64/bin/wkhtmltopdf-amd64 /usr/local/bin/`

which would make the binary file `wkhtmltopdf-amd64` instead of `wkhtmltopdf`.