### PR TITLE
Allow passing of multiple HTML Strings

### DIFF
--- a/src/PdfWrapper.php
+++ b/src/PdfWrapper.php
@@ -107,12 +107,12 @@ class PdfWrapper{
     /**
      * Load a HTML string
      *
-     * @param  string $string
+     * @param  Array|string $html
      * @return $this
      */
-    public function loadHTML($string)
+    public function loadHTML($html)
     {
-        $this->html = (string) $string;
+        $this->html = $html;
         $this->file = null;
         return $this;
     }


### PR DESCRIPTION
Snappy supports passing multiple HTML Strings to build a single Document from multiple HTML Sources. This Wrapper doesn't mirror the underlying function completly. Removing the explicit String Casting allows us to do something like this:

`PDF::loadHTML(array($content1, $content2))`