### PR TITLE
Use bind instead of singleton to prevent option leaking

### DIFF
--- a/src/LumenServiceProvider.php
+++ b/src/LumenServiceProvider.php
@@ -27,7 +27,7 @@ class LumenServiceProvider extends BaseServiceProvider
     public function boot()
     {
         if ($this->app['config']->get('snappy.pdf.enabled')) {
-            $this->app->singleton('snappy.pdf',function ($app) {
+            $this->app->bind('snappy.pdf',function ($app) {
                 $binary = $app['config']->get('snappy.pdf.binary', '/usr/local/bin/wkhtmltopdf');
                 $options = $app['config']->get('snappy.pdf.options', array());
                 $env = $app['config']->get('snappy.pdf.env', array());
@@ -41,14 +41,14 @@ class LumenServiceProvider extends BaseServiceProvider
                 return $snappy;
             });
 
-            $this->app->singleton('snappy.pdf.wrapper',function ($app) {
+            $this->app->bind('snappy.pdf.wrapper',function ($app) {
                 return new PdfWrapper($app['snappy.pdf']);
             });
             $this->app->alias('snappy.pdf.wrapper', 'Barryvdh\Snappy\PdfWrapper');
         }
 
         if ($this->app['config']->get('snappy.image.enabled')) {
-            $this->app->singleton('snappy.image',function ($app) {
+            $this->app->bind('snappy.image',function ($app) {
                 $binary = $app['config']->get('snappy.image.binary', '/usr/local/bin/wkhtmltoimage');
                 $options = $app['config']->get('snappy.image.options', array());
                 $env = $app['config']->get('snappy.image.env', array());
@@ -62,7 +62,7 @@ class LumenServiceProvider extends BaseServiceProvider
                 return $image;
             });
 
-            $this->app->singleton('snappy.image.wrapper',function ($app) {
+            $this->app->bind('snappy.image.wrapper',function ($app) {
                 return new ImageWrapper($app['snappy.image']);
             });
             $this->app->alias('snappy.image.wrapper', 'Barryvdh\Snappy\ImageWrapper');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,9 +26,9 @@ class ServiceProvider extends BaseServiceProvider {
     {
         $configPath = __DIR__ . '/../config/snappy.php';
         $this->publishes([$configPath => config_path('snappy.php')], 'config');
-        
+
         if($this->app['config']->get('snappy.pdf.enabled')){
-            $this->app->singleton('snappy.pdf', function($app)
+            $this->app->bind('snappy.pdf', function($app)
             {
                 $binary = $app['config']->get('snappy.pdf.binary', '/usr/local/bin/wkhtmltopdf');
                 $options = $app['config']->get('snappy.pdf.options', array());
@@ -43,7 +43,7 @@ class ServiceProvider extends BaseServiceProvider {
                 return $snappy;
             });
 
-            $this->app->singleton('snappy.pdf.wrapper', function($app)
+            $this->app->bind('snappy.pdf.wrapper', function($app)
             {
                 return new PdfWrapper($app['snappy.pdf']);
             });
@@ -52,7 +52,7 @@ class ServiceProvider extends BaseServiceProvider {
 
 
         if($this->app['config']->get('snappy.image.enabled')){
-            $this->app->singleton('snappy.image', function($app)
+            $this->app->bind('snappy.image', function($app)
             {
                 $binary = $app['config']->get('snappy.image.binary', '/usr/local/bin/wkhtmltoimage');
                 $options = $app['config']->get('snappy.image.options', array());

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -67,7 +67,7 @@ class ServiceProvider extends BaseServiceProvider {
                 return $image;
             });
 
-            $this->app->singleton('snappy.image.wrapper', function($app)
+            $this->app->bind('snappy.image.wrapper', function($app)
             {
                 return new ImageWrapper($app['snappy.image']);
             });


### PR DESCRIPTION
This is a quick fix for issue #246. 

Using bind instead of singleton always returns a new instance of snappy from the facade, to prevent options leaking between operations when generating multiple PDFs or images during the lifetime of the app.

I have not tested this thoroughly, but in quick tests I did not notice it would break any existing functionality.