### PR TITLE
prevent error is_file(): File name is longer than the maximum allowed path length on this platform

### DIFF
--- a/src/IlluminateSnappyPdf.php
+++ b/src/IlluminateSnappyPdf.php
@@ -50,7 +50,7 @@ class IlluminateSnappyPdf extends Pdf {
      */
     protected function isFile($filename)
     {
-        return $this->fs->isFile($filename);
+        return strlen($filename) <= PHP_MAXPATHLEN && $this->fs->isFile($filename);
     }
 
     /**


### PR DESCRIPTION
As the title states, when passing a view as an option (say for header-html/footer-html) and it tries to render it will trigger this error if we first don't check the content is not longer than max path length. 

```php
return PDF::loadView('pdfs.invoice',$data)
    ->setOption('margin-top',60)
    ->setOption('header-html',view('pdfs.invoice-header',$data))
    ->inline('invoice.pdf');
```