### PR TITLE
Allow option to customise the binary path

### DIFF
--- a/config/snappy.php
+++ b/config/snappy.php
@@ -35,7 +35,7 @@ return [
     
     'pdf' => [
         'enabled' => true,
-        'binary'  => '/usr/local/bin/wkhtmltopdf',
+        'binary'  => env('WKHTML_PDF_BINARY', '/usr/local/bin/wkhtmltopdf'),
         'timeout' => false,
         'options' => [],
         'env'     => [],
@@ -43,7 +43,7 @@ return [
     
     'image' => [
         'enabled' => true,
-        'binary'  => '/usr/local/bin/wkhtmltoimage',
+        'binary'  => env('WKHTML_IMG_BINARY', '/usr/local/bin/wkhtmltoimage'),
         'timeout' => false,
         'options' => [],
         'env'     => [],


### PR DESCRIPTION
Sometimes it is necessary to set the binary paths based on the environment. Here we may optionally use the environment variables `WKHTML_PDF_BINARY` and `WKHTML_IMG_BINARY` to set the binary paths. 

Eg: environments `local`, `staging` & `production`.