### PR TITLE
Removed phpunit deprecated methods in PdfFaker

### DIFF
--- a/src/PdfFaker.php
+++ b/src/PdfFaker.php
@@ -114,7 +114,7 @@ class PdfFaker extends PdfWrapper
      */
     public function assertSee($value)
     {
-        PHPUnit::assertContains($value, $this->html);
+        PHPUnit::assertStringContainsString($value, $this->html);
 
         return $this;
     }
@@ -127,7 +127,7 @@ class PdfFaker extends PdfWrapper
      */
     public function assertSeeText($value)
     {
-        PHPUnit::assertContains($value, strip_tags($this->html));
+        PHPUnit::assertStringContainsString($value, strip_tags($this->html));
 
         return $this;
     }
@@ -140,7 +140,7 @@ class PdfFaker extends PdfWrapper
      */
     public function assertDontSee($value)
     {
-        PHPUnit::assertNotContains($value, $this->html);
+        PHPUnit::assertStringNotContainsString($value, $this->html);
 
         return $this;
     }
@@ -153,7 +153,7 @@ class PdfFaker extends PdfWrapper
      */
     public function assertDontSeeText($value)
     {
-        PHPUnit::assertNotContains($value, strip_tags($this->html));
+        PHPUnit::assertStringNotContainsString($value, strip_tags($this->html));
 
         return $this;
     }


### PR DESCRIPTION
While I was recording a tutorial on this package, I found in the `PdfFaker.php` has Phpunit deprecated methods. 

You can see that right here:
https://www.youtube.com/watch?v=P43fuBbmD1c&t=1333s

I have replaced them with new methods in this PR.
`PHPUnit::assertContains` replaced with `PHPUnit::assertStringContainsString`
`PHPUnit::assertNotContains` replaced with `PHPUnit::assertStringNotContainsString`