### PR TITLE
Clarify timeout setting value

### DIFF
--- a/config/snappy.php
+++ b/config/snappy.php
@@ -17,10 +17,11 @@ return [
     |    
     |    The file path of the wkhtmltopdf / wkhtmltoimage executable.
     |
-    | Timout:
+    | Timeout:
     |    
     |    The amount of time to wait (in seconds) before PDF / Image generation is stopped.
-    |    Setting this to false disables the timeout (unlimited processing time).
+    |    Setting this to null disables the timeout (unlimited processing time).
+    |    Setting this to false uses the default timeout from the Symfony\Component\Process\Process class (60 seconds).
     |
     | Options:
     |


### PR DESCRIPTION
The current default value of the timeout options (false) results in the timeout not being changed by the Laravel ServiceProvider class or the `Knp\Snappy\AbstractGenerator` class (as both make explicit `if (false !== $timeout)` checks.  This results in the default timeout from the `Symfony\Component\Process\Process` class being used, 60 seconds.  I've adjusted the comment explaining this to clarify that the config must be changed to null to disable the timeout and added a note about what setting it to false is actually doing in practice.