### PR TITLE
Support UTF-8 filename

### DIFF
--- a/src/ImageWrapper.php
+++ b/src/ImageWrapper.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Response;
 use Knp\Snappy\Image as SnappyImage;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -137,10 +138,11 @@ class ImageWrapper {
      */
     public function download($filename = 'image.jpg')
     {
-        return new Response($this->output(), 200, array(
-            'Content-Type' => 'image/jpeg',
-            'Content-Disposition' =>  'attachment; filename="'.$filename.'"'
-        ));
+        Storage::put($filename, $this->output());
+
+        return response()
+            ->download(Storage::path('/').$filename)
+            ->deleteFileAfterSend();
     }
 
     /**

--- a/src/PdfWrapper.php
+++ b/src/PdfWrapper.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Response;
 use Knp\Snappy\Pdf as SnappyPDF;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Contracts\Support\Renderable;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -213,10 +214,11 @@ class PdfWrapper{
      */
     public function download($filename = 'document.pdf')
     {
-        return new Response($this->output(), 200, array(
-            'Content-Type' => 'application/pdf',
-            'Content-Disposition' =>  'attachment; filename="'.$filename.'"'
-        ));
+        Storage::put($filename, $this->output());
+
+        return response()
+            ->download(Storage::path('/').$filename)
+            ->deleteFileAfterSend();
     }
 
     /**


### PR DESCRIPTION
Using Laravel `response()->download()` to append `filename*=utf-8` to Content Disposition header when filename has `UTF-8` encode.