### PR TITLE
FIX Readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,13 +123,13 @@ $html = '<h1>Bill</h1><p>You owe me money, dude.</p>';
 $snappy->generateFromHtml($html, '/tmp/bill-123.pdf');
 $snappy->generate('http://www.github.com', '/tmp/github.pdf');
 //Or output:
-return new Response(
-    $snappy->getOutputFromHtml($html),
-    200,
-    array(
-        'Content-Type'          => 'application/pdf',
-        'Content-Disposition'   => 'attachment; filename="file.pdf"'
-    )
+return Response::make(
+    $snappy->getOutputFromHtml($html), 
+    200, 
+    [
+        'Content-Type' => 'application/pdf',
+        'Content-Disposition' => 'attachment; filename="file.pdf"'
+    ]
 );
 ```
 


### PR DESCRIPTION
Fix "Argument 1 passed to Symfony\Component\HttpFoundation\Response::setContent() must be of the type string or null, object given, called in C:\xampp\htdocs\project\vendor\laravel\framework\src\Illuminate\Http\Response.php on line 72"
When using example from readme.