### PR TITLE
Check file exists before delete

### DIFF
--- a/src/IlluminateSnappyPdf.php
+++ b/src/IlluminateSnappyPdf.php
@@ -74,7 +74,7 @@ class IlluminateSnappyPdf extends Pdf {
      */
     protected function unlink($filename)
     {
-        return $this->fs->delete($filename);
+        return $this->fileExists($filename) && $this->fs->delete($filename);
     }
 
     /**


### PR DESCRIPTION
I've been getting warnings for a while when `knplabs/knp-snappy` tries to cleanup temporary files (it calls the cleanup function twice).

I've resolved it with a small change to check the file exists before trying to delete.