### PR TITLE
ci: Use GitHub Actions V3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,7 +39,7 @@ jobs:
           sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v4
         with:
           php-version: ${{ matrix.php }}
           coverage: none


### PR DESCRIPTION
All annotated warning link to the official GitHub documentation: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/