### PR TITLE
Fix `Creation of dynamic property` warning in PHP 8.2 for SnappyImage

### DIFF
--- a/src/IlluminateSnappyImage.php
+++ b/src/IlluminateSnappyImage.php
@@ -4,6 +4,10 @@ use Knp\Snappy\Image;
 use Illuminate\Filesystem\Filesystem;
 
 class IlluminateSnappyImage extends Image {
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $fs;
 
 	/**
 	 * @param \Illuminate\Filesystem\Filesystem

--- a/src/ImageWrapper.php
+++ b/src/ImageWrapper.php
@@ -23,6 +23,15 @@ class ImageWrapper {
      */
     protected $options = array();
 
+    /**
+     * @var string
+     */
+    protected $html;
+
+    /**
+     * @var string
+     */
+    protected $file;
 
     /**
      * @param \Knp\Snappy\Image $snappy


### PR DESCRIPTION
The pdf side of the house was updated to fix the php 8.2 deprecation notices, but not the Image side. (https://github.com/barryvdh/laravel-snappy/pull/501)

This just fixes and updates that.

Would you also tag a release if you accept this please? Thank you!