### PR TITLE
Update readme.md with note about composer dependencies suggested

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ This package is a ServiceProvider for Snappy: [https://github.com/KnpLabs/snappy
 Choose one of the following options to install wkhtmltopdf/wkhtmltoimage.
 
 1. Download wkhtmltopdf from [here](http://wkhtmltopdf.org/downloads.html); 
-2. Or install as a composer dependency. See [wkhtmltopdf binary as composer dependencies](https://github.com/KnpLabs/snappy#wkhtmltopdf-binary-as-composer-dependencies) for more information.
+2. Or install as a composer dependency. See [wkhtmltopdf binary as composer dependencies](https://github.com/KnpLabs/snappy#wkhtmltopdf-binary-as-composer-dependencies) for more information. (Please note that, these composer dependencies are not using latest binaries with several fixes which you might need.)
 
 #### Attention! Please note that some dependencies (libXrender for example) may not be present on your system and may require manual installation. 
 


### PR DESCRIPTION
The suggested composer dependencies are not using latest binaries. Adding this note might save time for developers reading this doc for installation.